### PR TITLE
removed extra default image after error

### DIFF
--- a/app/prizetap/components/PrizeCard.tsx
+++ b/app/prizetap/components/PrizeCard.tsx
@@ -8,10 +8,7 @@ import { IoShareSocialOutline } from "react-icons/io5";
 import Link from "next/link";
 import { usePrizeTapContext } from "@/context/prizeTapProvider";
 
-export type PrizeCardProps = {
-  prize: Prize;
-  isHighlighted?: boolean;
-};
+export type PrizeCardProps = { prize: Prize; isHighlighted?: boolean };
 
 const nunitoSans = Nunito_Sans({
   weight: ["200", "300", "400", "600", "700"],
@@ -69,9 +66,9 @@ export const PrizeContent: FC<{ prize: Prize }> = ({ prize }) => {
         <div className="absolute -inset-[2px] left-0 top-0 -z-10 rotate-[5deg] rounded-xl bg-black-0"></div>
         <div className="rotate-3 rounded-xl border-2 bg-[#E5FFE2]">
           <img
-            src={
-              prize.image ?? "/quest/assets/images/prize-tap/default-prize.png"
-            }
+            // src={
+            //   prize.image ?? "/quest/assets/images/prize-tap/default-prize.png"
+            // }
             alt={prize.name}
             onError={(e) => {
               e.currentTarget.src =

--- a/components/containers/token-tap/TokenCardNew.tsx
+++ b/components/containers/token-tap/TokenCardNew.tsx
@@ -7,10 +7,7 @@ import Markdown from "react-markdown";
 import { IoShareSocialOutline } from "react-icons/io5";
 import Link from "next/link";
 
-export type TokenCardProps = {
-  token: Token;
-  isHighlighted?: boolean;
-};
+export type TokenCardProps = { token: Token; isHighlighted?: boolean };
 
 const nunitoSans = Nunito_Sans({
   weight: ["200", "300", "400", "600", "700"],
@@ -72,10 +69,10 @@ export const TokenContent: FC<{ token: Token }> = ({ token }) => {
               token.image ?? "/quest/assets/images/prize-tap/default-prize.png"
             }
             alt={token.name}
-            onError={(e) => {
-              e.currentTarget.src =
-                "/quest/assets/images/prize-tap/default-prize.png";
-            }}
+            // onError={(e) => {
+            //   e.currentTarget.src =
+            //     "/quest/assets/images/prize-tap/default-prize.png";
+            // }}
             width={231}
             height={231}
             className="h-[231px] w-[231px] rounded-xl object-cover"


### PR DESCRIPTION
## Summary by Sourcery

Removes the default image fallback from the PrizeCard and TokenCardNew components, but keeps the onError handler to display the default image if the image fails to load.